### PR TITLE
Do not merge: example for cert generation and extension build

### DIFF
--- a/dev/build_extension.py
+++ b/dev/build_extension.py
@@ -246,8 +246,8 @@ def _sign_plugin(args):
         extension_path,
         certificate_path,
         certificate_pwd,
-        "-tsa",
-        TIMESTAMP_URL,
+        # "-tsa",
+        # TIMESTAMP_URL,
     ]
 
     # execute the build script

--- a/dev/env.mk
+++ b/dev/env.mk
@@ -1,26 +1,26 @@
 
 # set this to the target version you want to set this to
-TARGET_VERSION=0.0.1
+TARGET_VERSION=9.0.0
 
 # set this to the core you are working with. eg:0.18.160
-TKCORE_VERSION=0.18.160
+# TKCORE_VERSION=0.18.160
 # if you want to use tk-core from a non default bundle-cache location,
 # uncomment the following line and set your path accordingly.
-# TKCORE_FOLDER=
+TKCORE_FOLDER=/Users/beelanj/git/tk-core
 
-ZXP_SIGN_TOOL=
+ZXP_SIGN_TOOL=/Users/beelanj/bin/ZXPSignCmd
 PYTHON_EXE=python
 
 # DO NOT COMMIT THE FOLLOWING LINES TO THE REPO
 # set this to your certificate file, that you created / will create
-CERTIFICATE_FILE=
+CERTIFICATE_FILE=/Users/beelanj/bin/test2.p12
 # set this to the password that you chose/want to chose for your certificate file
 # the following options are needed, when you want to create a new certificate
-CERTIFICATE_PASS=
-CERT_COUNTRY=
-CERT_STATE=
-CERT_ORG=
-CERT_CN=
+CERTIFICATE_PASS=123456
+CERT_COUNTRY=US
+CERT_STATE=WA
+CERT_ORG=Autodesk
+CERT_CN=SGTK
 
 # optional certificate fields (uncomment if desired)
 # CERT_LOCALITY:=


### PR DESCRIPTION
**The gist**: I've had to disable the timestamping of the signing process, and then see the gotchas below.

**Gotchas**: The certificate password needs to be at least 6-characters long. The `ZXPSignCmd` utility doesn't specify that, and if you give it fewer it'll just fail with a cryptic message. Note the other fields filled out in the `env.mk` related to the certificate, as well, and do something similar. It's not super critical what the specific values are, but it appears to be important that they're filled in.

Once your `env.mk` is setup similar to what I have here (but with a real password, please...and don't commit the `env.mk` once you've modified it locally), you'll be able to [run the make command to generate a p12 file](https://github.com/shotgunsoftware/tk-framework-adobe#to-create-a-certificate-for-use-when-signing-the-cep-extension).

Once you have your p12 generated on disk, you can [run the make sign command to build the extension and sign it using your certificate](https://github.com/shotgunsoftware/tk-framework-adobe#to-sign-the-cep-extension).