### PR TITLE
SG-35999 Create a hook for socketIO prepare_http_session

### DIFF
--- a/python/tk_framework_adobe/rpc/communicator.py
+++ b/python/tk_framework_adobe/rpc/communicator.py
@@ -48,7 +48,7 @@ except ImportError:
 
 if os.environ.get("SGTK_ENFORE_PROXY_LOCALHOST", "0").strip().lower() not in [
     "1",
-    "true"
+    "true",
     "y",
     "yes",
 ]:

--- a/python/tk_framework_adobe/rpc/communicator.py
+++ b/python/tk_framework_adobe/rpc/communicator.py
@@ -46,8 +46,11 @@ try:
 except ImportError:
     from tank_vendor import six as sgutils
 
-if os.environ.get("SGTK_ENFORE_PROXY_LOCALHOST", "0").lower() not in [
-    "1", "y", "yes",
+if os.environ.get("SGTK_ENFORE_PROXY_LOCALHOST", "0").strip().lower() not in [
+    "1",
+    "true"
+    "y",
+    "yes",
 ]:
     # Hook socketIO_client_nexus.prepare_http_session to disable Proxy
     prepare_http_session_bak = socketIO_client_nexus.prepare_http_session

--- a/python/tk_framework_adobe/rpc/communicator.py
+++ b/python/tk_framework_adobe/rpc/communicator.py
@@ -35,8 +35,8 @@ if not os.path.exists(pkgs_zip_path):
 sys.path.insert(0, pkgs_zip_path)
 
 
+import socketIO_client_nexus
 import socketIO_client_nexus.exceptions
-from socketIO_client_nexus import SocketIO
 from .proxy import ProxyScope, ProxyWrapper, ClassInstanceProxyWrapper
 
 import sgtk
@@ -45,6 +45,17 @@ try:
     from tank_vendor import sgutils
 except ImportError:
     from tank_vendor import six as sgutils
+
+
+## Hook socketIO_client_nexus.prepare_http_session to disable Proxy
+prepare_http_session_bak = socketIO_client_nexus.prepare_http_session
+
+def my_prepare_http_session(kw):
+    http_session = prepare_http_session_bak(kw)
+    http_session.trust_env = False
+    return http_session
+
+socketIO_client_nexus.prepare_http_session=my_prepare_http_session
 
 
 class Communicator(object):
@@ -99,7 +110,7 @@ class Communicator(object):
         self._event_processor = event_processor
         self._response_logging_silenced = False
 
-        self._io = SocketIO(host, port)
+        self._io = socketIO_client_nexus.SocketIO(host, port)
         self._io.on("return", self._handle_response)
 
         self._global_scope = None

--- a/python/tk_framework_adobe/rpc/communicator.py
+++ b/python/tk_framework_adobe/rpc/communicator.py
@@ -112,18 +112,7 @@ class Communicator(object):
         self._event_processor = event_processor
         self._response_logging_silenced = False
 
-        my_logger = sgtk.LogManager.get_logger(__name__)
-        my_logger.info("")
-        my_logger.info("")
-        my_logger.info("Create SocketIO client instance")
-
         self._io = socketIO_client_nexus.SocketIO(host, port)
-        my_logger.info(f"Instance: {self._io}")
-        my_logger.info(f"_http_session: {self._io._http_session}")
-
-        my_logger.info("")
-        my_logger.info("")
-
         self._io.on("return", self._handle_response)
 
         self._global_scope = None

--- a/python/tk_framework_adobe/rpc/communicator.py
+++ b/python/tk_framework_adobe/rpc/communicator.py
@@ -46,7 +46,7 @@ try:
 except ImportError:
     from tank_vendor import six as sgutils
 
-if os.environ.get("SGTK_ENFORE_PROXY_LOCALHOST", "0").strip().lower() not in [
+if os.environ.get("SGTK_ENFORCE_PROXY_LOCALHOST", "0").strip().lower() not in [
     "1",
     "true",
     "y",


### PR DESCRIPTION
The hook changes the `requests.session` instance setting `trust_env` to False and therefore not using the system proxy settings.

Add an `SGTK_ENFORE_PROXY_LOCALHOST` environment variable to recover the legacy behaviour.


Related to shotgunsoftware/tk-alias#208 and shotgunsoftware/tk-framework-alias#83. 

